### PR TITLE
Reduce size

### DIFF
--- a/snowline/utils/geo_utils.py
+++ b/snowline/utils/geo_utils.py
@@ -1,0 +1,31 @@
+import numpy as np
+
+FLOAT_PREC = 6
+def boundaries_to_geo(boundaries):
+    features = []
+    for boundary in boundaries:
+        features.append({'type': 'Feature',
+           'properties': {},
+           'geometry': {'type': 'Polygon',
+            'coordinates':[[(round(x, FLOAT_PREC), round(y, FLOAT_PREC))
+                    for x,y in b]
+                        for b in boundary]}})
+        #print('@', boundary[0])
+
+    return {'type': 'FeatureCollection',
+          'features':features}
+def geo_to_boundaries(geo_dict):
+    return [feat['geometry']['coordinates']
+            for feat in geo_dict['features']]
+
+
+
+def clean_up_line(points, deviation=0.1):
+    # get a line of points. remove all points that lie on the same line (except the very outer ones)
+    new_points = [points[0]]
+    
+    for idx, (point) in enumerate(points[1:-1], start=1):
+        if np.any(np.abs(0.5* (points[idx-1] + points[idx+1]) - point) > deviation):
+            new_points.append(point)
+    new_points.append(points[-1])
+    return new_points

--- a/snowline/utils/s3_io.py
+++ b/snowline/utils/s3_io.py
@@ -3,16 +3,22 @@ from snowline.analysis.snowmap import SnowMap
 from abc import ABCMeta
 
 
+FLOAT_PREC = 6
 def boundaries_to_geo(boundaries):
     features = []
     for boundary in boundaries:
         features.append({'type': 'Feature',
            'properties': {},
            'geometry': {'type': 'Polygon',
-            'coordinates':[b.tolist() for b in boundary]}})
+            'coordinates':[[(round(x, FLOAT_PREC), round(y, FLOAT_PREC))
+                    for x,y in b]
+                        for b in boundary]}})
+        #print('@', boundary[0])
 
     return {'type': 'FeatureCollection',
           'features':features}
+
+
 
 def geo_to_boundaries(geo_dict):
     return [feat['geometry']['coordinates']
@@ -103,7 +109,7 @@ class SnowlineDB(S3DB):
             if verbose:
                 print(" Done\nWriting snowline boundaries to {}...".format(new_sl_filename))
             with open(os.path.join(tmpdirname,new_sl_filename), 'w') as f:
-                json.dump(new_sl_data, f)
+                json.dump(new_sl_data, f, separators=(',', ':'))
 
 
             database['updated'] = timestamp


### PR DESCRIPTION
The size is reduced by a) reducing float precision and b) skipping over intermediate points on a straight line, when saving the snowline file. This will mitigate to some extent https://github.com/JamesRunnalls/frontend-snowlines/issues/4 . 
The size of an example snowline reduces from 4.4Mb to 2.1Mb with a) and from 2.1Mb to 1.4Mb with b).

I leave the branch because more solutions might be possible, e.g. compression of files.